### PR TITLE
Add  documentation typography example to base

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Contains another set of basic structures, such as: normalizes or mixins.
 **Basic files:**
 - **_normalize.sass**: stylesheet used to reset native browser properties.
 - **_reusables.sass**: contains structures that repeats throughout the project classes.
+- **_typography.sass**: set style for typography, such as headings and body font size, line height and font family using variables on ambience/typography.
 - **_unclassed.sass**: set styles for basic html tags, those who don't usually have a class.
 
 ## 3. Components

--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Contains another set of basic structures, such as: normalizes or mixins.
 
 **Basic files:**
 - **_normalize.sass**: stylesheet used to reset native browser properties.
+- **_reusables.sass**: contains structures that repeats throughout the project classes.
 - **_unclassed.sass**: set styles for basic html tags, those who don't usually have a class.
-- **_mixins.sass**: contains structures that repeats throughout the project classes.
 
 ## 3. Components
 


### PR DESCRIPTION
Add  documentation typography example to base and change name from mixins to reusables.